### PR TITLE
Add tests for asyncari

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,125 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from asyncari.client import Client
+from asyncari.model import Channel, Bridge, Playback, LiveRecording, StoredRecording, Endpoint, DeviceState, Sound
+
+@pytest.fixture
+def mock_taskgroup():
+    return MagicMock()
+
+@pytest.fixture
+def mock_http_client():
+    return MagicMock()
+
+@pytest.fixture
+def client(mock_taskgroup, mock_http_client):
+    return Client(mock_taskgroup, "http://localhost:8088/", ["test_app"], mock_http_client)
+
+@pytest.mark.asyncio
+async def test_client_initialization(client):
+    assert client.base_url == "http://localhost:8088/"
+    assert client._apps == ["test_app"]
+    assert client.taskgroup is not None
+    assert client.swagger is not None
+
+@pytest.mark.asyncio
+async def test_client_generate_id(client):
+    client._id_seq = 0
+    generated_id = client.generate_id("test")
+    assert generated_id.startswith("ARI.")
+    assert generated_id.endswith(".test1")
+
+@pytest.mark.asyncio
+async def test_client_is_my_id(client):
+    client._id_name = "ARI.test"
+    assert client.is_my_id("ARI.test")
+    assert client.is_my_id("ARI.test.1")
+    assert not client.is_my_id("ARI.other")
+
+@pytest.mark.asyncio
+async def test_client_connect(client):
+    with patch("asyncari.client.AsynchronousHttpClient") as mock_http_client:
+        mock_http_client.return_value = AsyncMock()
+        async with client.connect("http://localhost:8088/", "test_app", "username", "password") as ari_client:
+            assert isinstance(ari_client, Client)
+
+@pytest.mark.asyncio
+async def test_client_close(client):
+    client.swagger.close = AsyncMock()
+    await client.close()
+    client.swagger.close.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_client_get_repo(client):
+    client.repositories = {"test_repo": "test_value"}
+    assert client.get_repo("test_repo") == "test_value"
+    assert client.get_repo("non_existent_repo") is None
+
+@pytest.mark.asyncio
+async def test_client_on_event(client):
+    handler = client.on_event("test_event")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+
+@pytest.mark.asyncio
+async def test_client_on_object_event(client):
+    handler = client.on_object_event("test_event", Channel, "Channel")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+    assert handler.mangler is not None
+
+@pytest.mark.asyncio
+async def test_client_on_channel_event(client):
+    handler = client.on_channel_event("test_event")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+    assert handler.mangler is not None
+
+@pytest.mark.asyncio
+async def test_client_on_bridge_event(client):
+    handler = client.on_bridge_event("test_event")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+    assert handler.mangler is not None
+
+@pytest.mark.asyncio
+async def test_client_on_playback_event(client):
+    handler = client.on_playback_event("test_event")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+    assert handler.mangler is not None
+
+@pytest.mark.asyncio
+async def test_client_on_live_recording_event(client):
+    handler = client.on_live_recording_event("test_event")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+    assert handler.mangler is not None
+
+@pytest.mark.asyncio
+async def test_client_on_stored_recording_event(client):
+    handler = client.on_stored_recording_event("test_event")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+    assert handler.mangler is not None
+
+@pytest.mark.asyncio
+async def test_client_on_endpoint_event(client):
+    handler = client.on_endpoint_event("test_event")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+    assert handler.mangler is not None
+
+@pytest.mark.asyncio
+async def test_client_on_device_state_event(client):
+    handler = client.on_device_state_event("test_event")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+    assert handler.mangler is not None
+
+@pytest.mark.asyncio
+async def test_client_on_sound_event(client):
+    handler = client.on_sound_event("test_event")
+    assert handler.event_type == "test_event"
+    assert handler.client == client
+    assert handler.mangler is not None

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,18 @@
+import pytest
+import subprocess
+import os
+
+EXAMPLES_DIR = "examples/basic"
+
+@pytest.mark.parametrize("script", [
+    "bridge_example.py",
+    "example.py",
+    "originate_example.py",
+    "playback_example.py"
+])
+def test_example_scripts(script):
+    script_path = os.path.join(EXAMPLES_DIR, script)
+    result = subprocess.run(["python3", script_path], capture_output=True, text=True)
+    assert result.returncode == 0, f"Script {script} failed with return code {result.returncode}"
+    assert "ERROR" not in result.stderr, f"Script {script} produced errors: {result.stderr}"
+    assert "Traceback" not in result.stderr, f"Script {script} produced a traceback: {result.stderr}"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,35 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+import asyncari
+
+@pytest.fixture
+def mock_client():
+    with patch("asyncari.connect") as mock_connect:
+        mock_connect.return_value = AsyncMock()
+        yield mock_connect
+
+@pytest.mark.asyncio
+async def test_integration_connect(mock_client):
+    async with asyncari.connect("http://localhost:8088/", "test_app", "username", "password") as client:
+        assert client is not None
+        assert client.base_url == "http://localhost:8088/"
+        assert client._apps == ["test_app"]
+
+@pytest.mark.asyncio
+async def test_integration_authentication(mock_client):
+    async with asyncari.connect("http://localhost:8088/", "test_app", "username", "password") as client:
+        assert client.swagger.http_client.auth.username == "username"
+        assert client.swagger.http_client.auth.password == "password"
+
+@pytest.mark.asyncio
+async def test_integration_api_calls(mock_client):
+    async with asyncari.connect("http://localhost:8088/", "test_app", "username", "password") as client:
+        client.swagger.channels.list = AsyncMock(return_value=[])
+        channels = await client.swagger.channels.list()
+        assert channels == []
+        client.swagger.bridges.list = AsyncMock(return_value=[])
+        bridges = await client.swagger.bridges.list()
+        assert bridges == []
+        client.swagger.endpoints.list = AsyncMock(return_value=[])
+        endpoints = await client.swagger.endpoints.list()
+        assert endpoints == []


### PR DESCRIPTION
Related to #1

Add unit tests, integration tests, and end-to-end tests for the `asyncari` project.

**Unit Tests**
* Add `tests/test_client.py` to test the `Client` class.
* Use mock objects to simulate external dependencies.

**Integration Tests**
* Add `tests/test_integration.py` to test real-world scenarios using the ARI client.
* Test connection, authentication, and various API calls.

**End-to-End Tests**
* Add `tests/test_e2e.py` to execute example scripts in the `examples` directory.
* Verify that the scripts produce the expected output.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/skypro1111/asyncari/issues/1?shareId=9dab335e-cc16-481e-b907-e2889ea43abd).